### PR TITLE
fixed npm version in package.json

### DIFF
--- a/pyrrha-dashboard/api-auth/.gitignore
+++ b/pyrrha-dashboard/api-auth/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 vcap-local.json
+vcap-local-dev.json

--- a/pyrrha-dashboard/api-auth/package.json
+++ b/pyrrha-dashboard/api-auth/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "engines": {
     "node": "^16.3.0",
-    "npm": "6.14.11"
+    "npm": "^8.1.2"
   },
   "license": "Apache-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
Signed-off-by: Upkar Lidder <ulidder@us.ibm.com>

**Describe at a high level the solution you're providing**
GitHub action failing with the following error:

```
 ---> Running in c93fee8c17aa
npm WARN EBADENGINE Unsupported engine ***
npm WARN EBADENGINE   package: 'api-auth@0.0.1',
npm WARN EBADENGINE   required: *** node: '^16.3.0', npm: '6.14.11' ***
npm WARN EBADENGINE   current: *** node: 'v16.13.1', npm: '8.1.2' ***
npm WARN EBADENGINE ***
npm notice 
```

Updating npm version to `^8.1.2`