### PR TITLE
Ul fix api-auth dockerfile permissions

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           VCAP_LOCAL: ${{ secrets.VCAP_LOCAL_DEV }}
         run: |
-          echo "$VCAP_LOCAL_DEV" >> ./pyrrha-dashboard/api-auth/vcap-local.json
+          echo "$VCAP_LOCAL" >> ./pyrrha-dashboard/api-auth/vcap-local.json
       
       # A GitHub Action for serializing workflow runs
       - name: Turnstyle

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,9 +12,12 @@ env:
   IBM_CLOUD_RESOURCE_GROUP: ${{ secrets.IBM_CLOUD_RESOURCE_GROUP_DEV }}
   ICR_REGION: ${{ secrets.ICR_REGION_DEV }}
   ICR_NAMESPACE: ${{ secrets.ICR_NAMESPACE_DEV }}
-  REGISTRY_HOSTNAME: ${{ secrets.ICR_REGISTRY_HOSTNAME_DEV }}
+  ICR_REGISTRY_HOSTNAME: ${{secrets.ICR_REGISTRY_HOSTNAME_DEV}}
   IKS_CLUSTER: ${{ secrets.IKS_CLUSTER_DEV }}
   K8S_CLUSTER_NAMESPACE: ${{ secrets.K8S_CLUSTER_NAMESPACE_DEV }}
+  IKS_DEPLOYMENT_NAME: ${{ secrets.IKS_DEPLOYMENT_NAME_DEV }}
+  CONTAINER_NAME: ${{ secrets.CONTAINER_NAME_DEV }}
+  IMAGE_NAME: ${{ secrets.IMAGE_NAME_DEV }}
   
 
 jobs:
@@ -50,7 +53,7 @@ jobs:
       #     image-name: api-main
       #     k8s-cluster-name: $IKS_CLUSTER
       #     k8s-cluster-namespace: $K8S_CLUSTER_NAMESPACE
-      #     registry-hostname: uk.icr.io
+      #     registry-hostname: $ICR_REGISTRY_HOSTNAME
       #     working-directory: "pyrrha-dashboard/api-main"
 
       - name: Deploy api-auth
@@ -67,7 +70,7 @@ jobs:
           image-name: api-auth
           k8s-cluster-name: $IKS_CLUSTER
           k8s-cluster-namespace: $K8S_CLUSTER_NAMESPACE
-          registry-hostname: uk.icr.io
+          registry-hostname: $ICR_REGISTRY_HOSTNAME
           working-directory: "pyrrha-dashboard/api-auth"
 
       # - name: Deploy api-dash
@@ -84,5 +87,5 @@ jobs:
       #     image-name: api-dash
       #     k8s-cluster-name: $IKS_CLUSTER
       #     k8s-cluster-namespace: $K8S_CLUSTER_NAMESPACE
-      #     registry-hostname: uk.icr.io
+      #     registry-hostname: $ICR_REGISTRY_HOSTNAME
       #     working-directory: "pyrrha-dashboard"

--- a/pyrrha-dashboard/api-auth/Dockerfile
+++ b/pyrrha-dashboard/api-auth/Dockerfile
@@ -1,10 +1,11 @@
-FROM registry.access.redhat.com/ubi8/nodejs-16
+FROM registry.access.redhat.com/ubi8/nodejs-16@sha256:c48eab04f1ddc5775f3da5ec126eac2ba2f76c187e462b901a7d7c29345aba55
 
 WORKDIR /app
 
-RUN chown -R 1001:0 /app
-
 COPY package.json /app
+
+USER root
+
 RUN npm install --only=prod
 COPY server.js /app
 COPY rest /app/rest
@@ -17,8 +18,6 @@ COPY vcap-local.json /app
 COPY graphql /app/graphql
 COPY _mockData /app/_mockData
 COPY schema.graphql /app
-
-
 
 ENV NODE_ENV production
 ENV PORT 4000

--- a/pyrrha-dashboard/api-auth/package.json
+++ b/pyrrha-dashboard/api-auth/package.json
@@ -2,8 +2,8 @@
   "name": "api-auth",
   "version": "0.0.1",
   "engines": {
-    "node": "^16.3.0",
-    "npm": "^8.1.2"
+    "node": "16.13.1",
+    "npm": "8.1.2"
   },
   "license": "Apache-2.0",
   "main": "src/index.js",

--- a/pyrrha-dashboard/api-auth/package.json
+++ b/pyrrha-dashboard/api-auth/package.json
@@ -2,8 +2,8 @@
   "name": "api-auth",
   "version": "0.0.1",
   "engines": {
-    "node": "16.13.1",
-    "npm": "8.1.2"
+    "node": "^16.13.1",
+    "npm": "^8.1.2"
   },
   "license": "Apache-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
Signed-off-by: Upkar Lidder <ulidder@us.ibm.com>

**Describe at a high level the solution you're providing**
- [ ] pinned UBI base images so the GitHub action does not break if the latest images is different
- [ ] updated node.js version in package.json file
- [ ] when you build an image on a Red Hat UBI that includes a language runtime, the user is already switched to a non-root user named `default`. Added `USER root` up front to avoid permission errors and `USER 1001` at the end to switch to non root user to run the container.
