### PR TITLE
Using build args to insert websocket URL at docker build stage

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -21,15 +21,12 @@ env:
   IKS_DEPLOYMENT_NAME: ${{ secrets.IKS_DEPLOYMENT_NAME_DEV }}
   CONTAINER_NAME: ${{ secrets.CONTAINER_NAME_DEV }}
   IMAGE_NAME: ${{ secrets.IMAGE_NAME_DEV }}
-  REACT_APP_WEBSOCKET_URL: ${{ secrets.REACT_APP_WEBSOCKET_URL }}
   
 
 jobs:
   setup-build-publish-deploy:
     name: Setup, Build, Publish, and Deploy 
     runs-on: ubuntu-latest
-    env:
-      REACT_APP_WEBSOCKET_URL: $REACT_APP_WEBSOCKET_URL
     
     steps:
       - uses: actions/checkout@v2      
@@ -44,6 +41,12 @@ jobs:
         uses: softprops/turnstyle@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update REACT_APP_WEBSOCKET_URL for Docker Build
+        env:
+          REACT_APP_WEBSOCKET_URL: ${{secrets.REACT_APP_WEBSOCKET_URL_DEV}}
+        run: |
+          sed -i "s|PYRRHA_WS_URL|$REACT_APP_WEBSOCKET_URL|" ./pyrrha-dashboard/Dockerfile
+          grep -i "REACT_APP" ./pyrrha-dashboard/Dockerfile
 
       - name: Deploy api-main
         uses: call-for-code/build-push-deploy@main

--- a/pyrrha-dashboard/Dockerfile
+++ b/pyrrha-dashboard/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:16-alpine as build
+
+ARG REACT_APP_WEBSOCKET_URL=PYRRHA_WS_URL
+
 WORKDIR /app
 COPY package.json .
 COPY nginx.conf .


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
Using build args at docker build time to insert WEBSOCKET_URL into the dockerfile.
- [x] added a placeholder `PYRRHA_WS_URL` in Dockerfile
- [x] replace this placeholder with GitHub secret value using `sed` when the action is run

Note: as the URL is inserted at build time, anybody who has access to this built image will be able to see the URL using `docker history`. Currently we use private ICR registry to store the image, and so this should not be an issue. In any case the URL is also visible in the js file that comes out of `yarn build`. We can look at options to minify perhaps.

![image](https://user-images.githubusercontent.com/3187457/160252307-28bca82c-d242-4a0a-aa49-22bbb8277a46.png)

Ideally, the `call-for-code/build-push-deploy@main` action would accept build args, but it does not in it's current form.

@hawk4031 pls review. Thank you!