### PR TITLE
fix - locking mariadb pkg ver to 1.0.11, as 1.1.x versions are not compatible with base container images

### DIFF
--- a/pyrrha-dashboard/api-main/requirements.txt
+++ b/pyrrha-dashboard/api-main/requirements.txt
@@ -5,6 +5,6 @@ ibmcloudenv
 livereload
 flask_wtf
 requests
-mariadb
+mariadb==1.0.11
 python-dotenv
 black


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
The newer 1.1.x versions of the MariaDB Connector use a newer MariaDB Connector/C library that the base container images don’t have, so locking the python mariadb dependency to 1.0.11 in the requirements.txt file fixes this issue. 

**Is this a patch, a minor version change, or a major version change**
Patch

**Is this related to an open issue?**
No

**Additional context**
None